### PR TITLE
security: Pin Github Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -40,7 +40,7 @@ jobs:
         run: dotnet test --no-restore --verbosity normal
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: Package
           path: |


### PR DESCRIPTION
Pins all third-party GitHub Actions in workflows and composite actions to immutable commit SHAs, with the resolved tag preserved in a trailing comment.

Generated by `pin_github_actions.py`.